### PR TITLE
Feature - Switch host to mainnet & update styling

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -21,6 +21,14 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <!-- Analytics -->
+    <script>
+      !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
+        analytics.load("ZGOnMWY4A5epIqq8RBpwQxoHfztNrslW");
+        // analytics.page();
+      }}();
+    </script>
     <title>Sparkswap Orderbook</title>
   </head>
   <body>

--- a/public/index.html
+++ b/public/index.html
@@ -26,7 +26,6 @@
     <script>
       !function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on"];analytics.factory=function(t){return function(){var e=Array.prototype.slice.call(arguments);e.unshift(t);analytics.push(e);return analytics}};for(var t=0;t<analytics.methods.length;t++){var e=analytics.methods[t];analytics[e]=analytics.factory(e)}analytics.load=function(t,e){var n=document.createElement("script");n.type="text/javascript";n.async=!0;n.src="https://cdn.segment.com/analytics.js/v1/"+t+"/analytics.min.js";var a=document.getElementsByTagName("script")[0];a.parentNode.insertBefore(n,a);analytics._loadOptions=e};analytics.SNIPPET_VERSION="4.1.0";
         analytics.load("ZGOnMWY4A5epIqq8RBpwQxoHfztNrslW");
-        // analytics.page();
       }}();
     </script>
     <title>Sparkswap Orderbook</title>

--- a/src/App.css
+++ b/src/App.css
@@ -67,3 +67,19 @@
   color: inherit;
   text-decoration: inherit;
 }
+
+.App .green-text {
+  color: green;
+}
+
+.App .red-text {
+  color: red;
+}
+
+.App .black-text {
+  color: black;
+}
+
+.App .gray-text {
+  color: gray;
+}

--- a/src/App.css
+++ b/src/App.css
@@ -59,7 +59,7 @@
   align-self: center;
 }
 
-.App .Footer .links * {
+.App .Footer .links .link-item {
   margin-left: 2em;
 }
 

--- a/src/App.css
+++ b/src/App.css
@@ -68,18 +68,18 @@
   text-decoration: inherit;
 }
 
-.App .green-text {
+.App .bid-sig-digits {
   color: green;
 }
 
-.App .red-text {
+.App .ask-sig-digits {
   color: red;
 }
 
-.App .black-text {
+.App .depth-sig-digits {
   color: black;
 }
 
-.App .gray-text {
+.App .non-sig-digits {
   color: gray;
 }

--- a/src/App.js
+++ b/src/App.js
@@ -33,10 +33,14 @@ class App extends Component {
       }
     ]
     this.host = 'https://viewer.mainnet.sparkswap.com:27592'
+
+    // This is hardcoded for demo purposes only
+    this.username = 'sparkswap'
+    this.password = 'sparkswap'
   }
 
   componentDidMount () {
-    this.marketData = new MarketData(this.markets[0].name, this.host)
+    this.marketData = new MarketData(this.markets[0].name, this.host, this.username, this.password)
     this.marketData.on('update', (orderbook) => {
       this.setState({ orderbook })
     })

--- a/src/App.js
+++ b/src/App.js
@@ -40,6 +40,9 @@ class App extends Component {
   }
 
   componentDidMount () {
+    // Analytics
+    window.analytics.page('Home')
+
     this.marketData = new MarketData(this.markets[0].name, this.host, this.username, this.password)
     this.marketData.on('update', (orderbook) => {
       this.setState({ orderbook })
@@ -48,6 +51,9 @@ class App extends Component {
   }
 
   showMailingPopUp () {
+    // Analytics
+    App.trackLink('Mailing Popup')
+
     window.dojoRequire(["mojo/signup-forms/Loader"], function(L) {
       L.start({
         "baseUrl": "mc.us20.list-manage.com",
@@ -59,6 +65,10 @@ class App extends Component {
     document.cookie = 'MCPopupClosed=;path=/;expires=Thu, 01 Jan 1970 00:00:00 UTC;';
     document.cookie = 'MCPopupSubscribed=;path=/;expires=Thu, 01 Jan 1970 00:00:00 UTC;';
   };
+
+  static trackLink (link) {
+    window.analytics.track(link)
+  }
 
   /**
    * Generates an array of HTLM elements (in JSX) that represents the orderbook as a
@@ -217,15 +227,15 @@ class App extends Component {
               </a>
             </div>
             <div className="links">
-              <a href="https://sparkswap.com/chat" className="link-item">
+              <a href="https://sparkswap.com/chat" className="link-item" onClick={() => App.trackLink('chat')}>
                 <Icon name="discord" />
                 Chat
               </a>
-              <a href="https://sparkswap.com/docs/getting-started" className="link-item">
+              <a href="https://sparkswap.com/docs/getting-started" className="link-item" onClick={() => App.trackLink('docs')}>
                 <Icon name="file alternate" />
                 Docs
               </a>
-              <a href="https://sparkswap.com/onboarding" className="link-item">
+              <a href="https://sparkswap.com/onboarding" className="link-item" onClick={() => App.trackLink('help')}>
                 <Icon name="life ring" />
                 Get Help
               </a>

--- a/src/App.js
+++ b/src/App.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Button, Container, Header, Image, Segment, Table } from 'semantic-ui-react'
+import { Button, Container, Header, Icon, Image, Segment, Table } from 'semantic-ui-react'
 import MarketSelector from './market-selector.js'
 import MarketData from './market-data.js'
 import icon from './icon.svg';
@@ -22,7 +22,7 @@ class App extends Component {
         name: 'BTC/LTC'
       }
     ]
-    this.host = 'http://127.0.0.1:27592'
+    this.host = 'https://viewer.mainnet.sparkswap.com:27592'
   }
 
   componentDidMount () {
@@ -73,7 +73,7 @@ class App extends Component {
             </a>
             <div className="Install">
               <a href="https://sparkswap.com/docs/getting-started">
-                <Button size="large" color='grey'>Install Now</Button>
+                <Button size="large" color='black'>Install Now</Button>
               </a>
             </div>
             <div className="market-selector">
@@ -114,9 +114,22 @@ class App extends Component {
               </a>
             </div>
             <div className="links">
-              <a href="https://sparkswap.com/chat">Chat</a>
-              <a href="https://sparkswap.com/onboarding">Get Help</a>
-              <a href="#" onClick={this.showMailingPopUp}>Subscribe to Updates</a>
+              <a href="https://sparkswap.com/chat" className="link-item">
+                <Icon name="discord" />
+                Chat
+              </a>
+              <a href="https://github.com/sparkswap" className="link-item">
+                <Icon name="github" />
+                GitHub
+              </a>
+              <a href="https://sparkswap.com/onboarding" className="link-item">
+                <Icon name="life ring" />
+                Get Help
+              </a>
+              <a href="#" onClick={this.showMailingPopUp} className="link-item">
+                <Icon name="newspaper" />
+                Subscribe to Updates
+              </a>
             </div>
           </Segment>
         </Container>

--- a/src/App.js
+++ b/src/App.js
@@ -215,16 +215,16 @@ class App extends Component {
                 <Icon name="discord" />
                 Chat
               </a>
-              <a href="https://github.com/sparkswap" className="link-item">
-                <Icon name="github" />
-                GitHub
+              <a href="https://sparkswap.com/docs/getting-started" className="link-item">
+                <Icon name="file alternate" />
+                Docs
               </a>
               <a href="https://sparkswap.com/onboarding" className="link-item">
                 <Icon name="life ring" />
                 Get Help
               </a>
               <a href="#" onClick={this.showMailingPopUp} className="link-item">
-                <Icon name="newspaper" />
+                <Icon name="envelope" />
                 Subscribe to Updates
               </a>
             </div>

--- a/src/App.js
+++ b/src/App.js
@@ -41,7 +41,7 @@ class App extends Component {
 
   componentDidMount () {
     // Analytics
-    window.analytics.page('Home')
+    window.analytics.page('Orderbook')
 
     this.marketData = new MarketData(this.markets[0].name, this.host, this.username, this.password)
     this.marketData.on('update', (orderbook) => {
@@ -195,7 +195,7 @@ class App extends Component {
             </a>
             <div className="Install">
               <a href="https://sparkswap.com/docs/getting-started">
-                <Button size="large" color='black'>Install Now</Button>
+                <Button size="large" color='black' onClick={() => App.trackLink('install')}>Install Now</Button>
               </a>
             </div>
             <div className="market-selector">

--- a/src/App.js
+++ b/src/App.js
@@ -116,7 +116,7 @@ class App extends Component {
     const formatted = []
     if (needsGrayColoring) {
       const significantDigits = [...text].slice(0, firstNonSigZero)
-      const nonSigDigits = (<span className='gray-text'>{[...text].slice(firstNonSigZero)}</span>)
+      const nonSigDigits = (<span className='non-sig-digits'>{[...text].slice(firstNonSigZero)}</span>)
 
       formatted.push(App.addColoring(significantDigits, type), nonSigDigits)
     } else {
@@ -136,11 +136,11 @@ class App extends Component {
   static addColoring (text, type) {
     switch (type) {
       case FORMAT_TYPES.BID:
-        return (<span className='green-text'>{text}</span>)
+        return (<span className='bid-sig-digits'>{text}</span>)
       case FORMAT_TYPES.ASK:
-        return (<span className='red-text'>{text}</span>)
+        return (<span className='ask-sig-digits'>{text}</span>)
       case FORMAT_TYPES.DEPTH:
-        return (<span className='black-text'>{text}</span>)
+        return (<span className='depth-sig-digits'>{text}</span>)
     }
   }
 

--- a/src/App.js
+++ b/src/App.js
@@ -141,6 +141,8 @@ class App extends Component {
         return (<span className='ask-sig-digits'>{text}</span>)
       case FORMAT_TYPES.DEPTH:
         return (<span className='depth-sig-digits'>{text}</span>)
+      default:
+        return (<span>{text}</span>)
     }
   }
 

--- a/src/market-data.js
+++ b/src/market-data.js
@@ -4,10 +4,12 @@ import EventEmitter from 'events'
 const ORDERBOOK_URL = '/v1/orderbook'
 
 class MarketData extends EventEmitter {
-  constructor (market, host, pollEvery = 3000) {
+  constructor (market, host, username, password, pollEvery = 3000) {
     super()
     this.market = market
     this.host = host
+    this.username = username
+    this.password = password
     this.pollEvery = pollEvery
   }
 
@@ -15,8 +17,8 @@ class MarketData extends EventEmitter {
     const config = {
       // This auth is used for demo purposes only
       auth: {
-        username: 'sparkswap',
-        password: 'sparkswap'
+        username: this.username,
+        password: this.password
       }
     }
 


### PR DESCRIPTION
This PR updates the host from `http://127.0.0.1:27592 ` to `https://viewer.mainnet.sparkswap.com:27592` and adds analytics using `segment.io`. There are also a few styling updates:
- Formatted numbers in orderbook (grayed out after last significant digit)
- More prominent Call To Action (bold black and open to changing the color)
- Icons next to links at bottom

Before
---
![image](https://user-images.githubusercontent.com/11034691/55689084-67bba400-5935-11e9-8a04-9f929b1c0b87.png)

After
---
![image](https://user-images.githubusercontent.com/11034691/55689834-7064a800-593e-11e9-88bc-ad43392ab218.png)

