### PR TITLE
Feature - Stacked orderbook on mobile

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -111,3 +111,32 @@
 .App .non-sig-digits {
   color: gray;
 }
+
+.App .table-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+.App .orders-table {
+  max-width: 350px;
+  align-self: center;
+}
+
+.ui.table tr td {
+  border-top: 0;
+  padding-top: 0;
+  padding-bottom: 0;
+}
+
+.App .hidden {
+  visibility: hidden;
+}
+
+
+.ui.table.basic tbody tr .bid-ask-delim-border {
+  border-bottom: 1px solid rgba(0,0,0,.1);
+}
+
+.App .order-mobile {
+  font-size: .8em;
+}


### PR DESCRIPTION
This PR renders a stacked orderbook on devices smaller than 768px. Before, the user needed to scroll horizontally on mobile devices to see bids and asks.

Test Deployment: https://build-irrsfokitg.now.sh

Before
---
![image](https://user-images.githubusercontent.com/11034691/55761202-5ba61400-5a13-11e9-87d8-62cab753a95e.png)

After
---
![image](https://user-images.githubusercontent.com/11034691/55761248-79737900-5a13-11e9-9113-2b5ca086adc8.png)